### PR TITLE
fix: correct shell syntax error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
           cp ./binaries/radar-agent-linux/radar-agent-linux ./radar-agent-linux
           cp ./binaries/radar-agent-linux-musl/radar-agent-linux-musl ./radar-agent-linux-musl
           cp ./binaries/radar-agent-linux-arm64/radar-agent-linux-arm64 ./radar-agent-linux-arm64
-            radar-agent-linux-arm64-musl
           cp ./binaries/radar-agent-linux-arm64-musl/radar-agent-linux-arm64-musl ./radar-agent-linux-arm64-musl
           cp ./binaries/radar-agent-darwin/radar-agent-darwin ./radar-agent-darwin
 


### PR DESCRIPTION
## Summary
- Fixed syntax error in the release workflow where the `cp` command for `radar-agent-linux-arm64-musl` was incorrectly split across two lines (lines 36-37)
- This was causing the workflow to fail with error: `radar-agent-linux-arm64-musl: command not found`

## Changes
- Removed the erroneous line break that caused the second part of the filename to be interpreted as a shell command
- The `cp` command is now properly formatted on a single line

## Test plan
- [ ] Verify the workflow runs successfully without syntax errors
- [ ] Confirm all binaries are copied correctly during the build process
- [ ] Check that the chmod and ls commands execute without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)