### PR TITLE
fix: correct Linux ARM64 installation instructions in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,13 +193,13 @@ jobs:
             ```
 
             **Linux ARM64 (glibc):**
+            ```bash
+            curl -L "https://github.com/redis-field-engineering/radar-agent/releases/download/${{ steps.tag.outputs.tag_name }}/radar-agent-linux-arm64" -o radar-agent
+            ```
 
             **Linux ARM64 (musl - for Alpine):**
             ```bash
             curl -L "https://github.com/redis-field-engineering/radar-agent/releases/download/${{ steps.tag.outputs.tag_name }}/radar-agent-linux-arm64-musl" -o radar-agent
-            ```
-            ```bash
-            curl -L "https://github.com/redis-field-engineering/radar-agent/releases/download/${{ steps.tag.outputs.tag_name }}/radar-agent-linux-arm64" -o radar-agent
             ```
 
             **macOS (Apple Silicon):**


### PR DESCRIPTION
## Summary
- Fixed formatting issues in the release notes where the Linux ARM64 installation instructions were incorrectly ordered and missing proper code blocks
- The Linux ARM64 (glibc) section was missing its code block entirely
- The code blocks were showing the wrong binaries for each section

## Changes
- Added proper code block for **Linux ARM64 (glibc)** showing `radar-agent-linux-arm64`
- Fixed **Linux ARM64 (musl)** code block to correctly show `radar-agent-linux-arm64-musl`
- Corrected the order to display glibc first, then musl for consistency

## Before
```markdown
**Linux ARM64 (glibc):**

**Linux ARM64 (musl - for Alpine):**
```bash
curl -L "https://github.com/redis-field-engineering/radar-agent/releases/download/v0.9.1/radar-agent-linux-arm64-musl" -o radar-agent
```
```bash
curl -L "https://github.com/redis-field-engineering/radar-agent/releases/download/v0.9.1/radar-agent-linux-arm64" -o radar-agent
```
```

## After
```markdown
**Linux ARM64 (glibc):**
```bash
curl -L "https://github.com/redis-field-engineering/radar-agent/releases/download/v0.9.1/radar-agent-linux-arm64" -o radar-agent
```

**Linux ARM64 (musl - for Alpine):**
```bash
curl -L "https://github.com/redis-field-engineering/radar-agent/releases/download/v0.9.1/radar-agent-linux-arm64-musl" -o radar-agent
```
```

## Test plan
- [ ] Verify the release notes render correctly when a new release is created
- [ ] Confirm both ARM64 installation commands are properly formatted with code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)