### PR TITLE
fix: align Dockerfile config paths with documentation (/etc/radar/radar-collector.yml)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,11 +16,11 @@ RUN apt-get update && \
     adduser --disabled-password --gecos "" appuser
 
 # Create necessary directories
-RUN mkdir -p /certs /etc/collector /home/appuser/bin && \
-    chown -R appuser:appuser /certs /etc/collector /home/appuser
+RUN mkdir -p /certs /etc/radar /home/appuser/bin && \
+    chown -R appuser:appuser /certs /etc/radar /home/appuser
 
 # Copy default config (customers may override via volume)
-COPY --chown=appuser:appuser radar-collector-config-sample.yml /etc/collector/config.yaml
+COPY --chown=appuser:appuser radar-collector-config-sample.yml /etc/radar/radar-collector.yml
 
 # Copy the collector binary
 COPY ${BINARY} /usr/local/bin/radar-collector
@@ -29,16 +29,16 @@ RUN chmod +x /usr/local/bin/radar-collector
 USER appuser
 
 # Environment defaults
-ENV COLLECTOR_CONFIG=/etc/collector/config.yaml \
+ENV COLLECTOR_CONFIG=/etc/radar/radar-collector.yml \
     COLLECTOR_TLS_CERT=/certs/server.pem \
     COLLECTOR_TLS_KEY=/certs/server.key
 
 # Expose volumes for certs and config
-VOLUME ["/certs", "/etc/collector"]
+VOLUME ["/certs", "/etc/radar"]
 
 # Healthcheck for orchestrators
 HEALTHCHECK --interval=30s --timeout=5s \
   CMD ["radar-collector", "--health"] || exit 1
 
 ENTRYPOINT ["radar-collector"]
-CMD ["--config", "/etc/collector/config.yaml"]
+CMD ["--config", "/etc/radar/radar-collector.yml"]

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -11,11 +11,11 @@ RUN apk add --no-cache ca-certificates
 
 # Create non-root user and necessary directories
 RUN adduser -D appuser \
-  && mkdir -p /certs /etc/collector /home/appuser/bin \
-  && chown -R appuser:appuser /certs /etc/collector /home/appuser
+  && mkdir -p /certs /etc/radar /home/appuser/bin \
+  && chown -R appuser:appuser /certs /etc/radar /home/appuser
 
 # Copy default config (customers may override via volume)
-COPY --chown=appuser:appuser radar-collector-config-sample.yml /etc/collector/config.yaml
+COPY --chown=appuser:appuser radar-collector-config-sample.yml /etc/radar/radar-collector.yml
 
 # Copy the collector binary
 COPY ${BINARY} /usr/local/bin/radar-collector
@@ -24,16 +24,16 @@ USER appuser
 
 # Environment defaults
 ENV PATH="/home/appuser/bin:${PATH}" \
-  COLLECTOR_CONFIG=/etc/collector/config.yaml \
+  COLLECTOR_CONFIG=/etc/radar/radar-collector.yml \
   COLLECTOR_TLS_CERT=/certs/server.pem \
   COLLECTOR_TLS_KEY=/certs/server.key
 
 # Expose volumes for certs and config
-VOLUME ["/certs", "/etc/collector"]
+VOLUME ["/certs", "/etc/radar"]
 
 # Healthcheck for orchestrators
 HEALTHCHECK --interval=30s --timeout=5s \
   CMD ["radar-collector", "--health"] || exit 1
 
 ENTRYPOINT ["radar-collector"]
-CMD ["--config", "/etc/collector/config.yaml"]
+CMD ["--config", "/etc/radar/radar-collector.yml"]

--- a/docker/Dockerfile.alpine.multiplatform
+++ b/docker/Dockerfile.alpine.multiplatform
@@ -14,11 +14,11 @@ RUN apk add --no-cache \
     adduser -D -g "" appuser
 
 # Create necessary directories
-RUN mkdir -p /certs /etc/collector /home/appuser/bin && \
-    chown -R appuser:appuser /certs /etc/collector /home/appuser
+RUN mkdir -p /certs /etc/radar /home/appuser/bin && \
+    chown -R appuser:appuser /certs /etc/radar /home/appuser
 
 # Copy default config (customers may override via volume)
-COPY --chown=appuser:appuser radar-collector-config-sample.yml /etc/collector/config.yaml
+COPY --chown=appuser:appuser radar-collector-config-sample.yml /etc/radar/radar-collector.yml
 
 # Copy the correct binary based on architecture
 # For Alpine, we use musl binaries for both AMD64 and ARM64
@@ -34,16 +34,16 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 USER appuser
 
 # Environment defaults
-ENV COLLECTOR_CONFIG=/etc/collector/config.yaml \
+ENV COLLECTOR_CONFIG=/etc/radar/radar-collector.yml \
     COLLECTOR_TLS_CERT=/certs/server.pem \
     COLLECTOR_TLS_KEY=/certs/server.key
 
 # Expose volumes for certs and config
-VOLUME ["/certs", "/etc/collector"]
+VOLUME ["/certs", "/etc/radar"]
 
 # Healthcheck for orchestrators
 HEALTHCHECK --interval=30s --timeout=5s \
   CMD ["radar-collector", "--health"] || exit 1
 
 ENTRYPOINT ["radar-collector"]
-CMD ["--config", "/etc/collector/config.yaml"]
+CMD ["--config", "/etc/radar/radar-collector.yml"]

--- a/docker/Dockerfile.distroless
+++ b/docker/Dockerfile.distroless
@@ -23,7 +23,7 @@ LABEL org.opencontainers.image.source="https://github.com/redis-field-engineerin
 
 # Create dirs
 USER root
-RUN mkdir -p /certs
+RUN mkdir -p /certs /etc/radar
 
 # Copy binary & CA cert
 COPY --from=unpack /app/collector /usr/local/bin/radar-collector
@@ -31,8 +31,9 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 
 # Set ownership and volumes
 # (final image is nonroot by default)
-VOLUME ["/certs"]
-ENV COLLECTOR_TLS_CERT=/certs/server.pem \
+VOLUME ["/certs", "/etc/radar"]
+ENV COLLECTOR_CONFIG=/etc/radar/radar-collector.yml \
+    COLLECTOR_TLS_CERT=/certs/server.pem \
     COLLECTOR_TLS_KEY=/certs/server.key
 
 # Healthcheck
@@ -40,4 +41,4 @@ HEALTHCHECK --interval=30s --timeout=5s \
   CMD ["/usr/local/bin/radar-collector", "--health"] || exit 1
 
 ENTRYPOINT ["/usr/local/bin/radar-collector"]
-CMD ["--help"]
+CMD ["--config", "/etc/radar/radar-collector.yml"]

--- a/docker/Dockerfile.multiplatform
+++ b/docker/Dockerfile.multiplatform
@@ -17,11 +17,11 @@ RUN apt-get update && \
     adduser --disabled-password --gecos "" appuser
 
 # Create necessary directories
-RUN mkdir -p /certs /etc/collector /home/appuser/bin && \
-    chown -R appuser:appuser /certs /etc/collector /home/appuser
+RUN mkdir -p /certs /etc/radar /home/appuser/bin && \
+    chown -R appuser:appuser /certs /etc/radar /home/appuser
 
 # Copy default config (customers may override via volume)
-COPY --chown=appuser:appuser radar-collector-config-sample.yml /etc/collector/config.yaml
+COPY --chown=appuser:appuser radar-collector-config-sample.yml /etc/radar/radar-collector.yml
 
 # Copy the correct binary based on architecture
 # For amd64: use radar-collector-linux
@@ -44,16 +44,16 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 USER appuser
 
 # Environment defaults
-ENV COLLECTOR_CONFIG=/etc/collector/config.yaml \
+ENV COLLECTOR_CONFIG=/etc/radar/radar-collector.yml \
     COLLECTOR_TLS_CERT=/certs/server.pem \
     COLLECTOR_TLS_KEY=/certs/server.key
 
 # Expose volumes for certs and config
-VOLUME ["/certs", "/etc/collector"]
+VOLUME ["/certs", "/etc/radar"]
 
 # Healthcheck for orchestrators
 HEALTHCHECK --interval=30s --timeout=5s \
   CMD ["radar-collector", "--health"] || exit 1
 
 ENTRYPOINT ["radar-collector"]
-CMD ["--config", "/etc/collector/config.yaml"]
+CMD ["--config", "/etc/radar/radar-collector.yml"]


### PR DESCRIPTION
## Summary

- **All 5 production Dockerfiles** used `/etc/collector/config.yaml` as the default config path, but the [official documentation](https://redis-field-engineering.github.io/radar/installation.html), the radar monorepo (`agent/Dockerfile`, `k8s/docs-test/deployment.yaml`, `docker-compose.yml`), and K8s Quick Start examples all expect `/etc/radar/radar-collector.yml`.
- This mismatch caused mounted ConfigMaps/volumes to be **silently ignored** — the container would load the built-in sample config instead, producing cryptic environment variable errors.
- `Dockerfile.distroless` additionally defaulted to `CMD ["--help"]` instead of loading config, and had no `/etc/radar` volume.

### Files changed

| Dockerfile | Changes |
|---|---|
| `Dockerfile` (Debian) | `/etc/collector/config.yaml` → `/etc/radar/radar-collector.yml` across mkdir, COPY, ENV, VOLUME, CMD |
| `Dockerfile.alpine` | Same as above |
| `Dockerfile.alpine.multiplatform` | Same as above (this builds the `alpine-latest` tag used in K8s Quick Start) |
| `Dockerfile.multiplatform` | Same as above (this builds the `latest` and `debian-latest` tags) |
| `Dockerfile.distroless` | Added `/etc/radar` dir + volume, `COLLECTOR_CONFIG` env var, replaced `CMD ["--help"]` with `CMD ["--config", "/etc/radar/radar-collector.yml"]` |

### What was wrong

The Docker documentation states:
> The default entrypoint runs `radar-collector --config /etc/radar/radar-collector.yml`, so you only need to mount the config file to the expected path.

But the actual images were running `--config /etc/collector/config.yaml`, meaning a user who followed the docs:

```yaml
docker run -v /path/to/radar-collector.yml:/etc/radar/radar-collector.yml \
  ghcr.io/redis-field-engineering/radar-collector:alpine-latest
```

…would have their config silently ignored.

## Test plan

- [ ] Build each Dockerfile locally and verify `docker inspect` shows the correct CMD and ENV
- [ ] Run `docker run --rm <image> --help` to verify the entrypoint still works
- [ ] Mount a config file to `/etc/radar/radar-collector.yml` and verify it is loaded (check logs for config path)
- [ ] Verify K8s docs-test deployment works without needing explicit `args` override


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default config file locations, volumes, and container CMDs in all shipped images, which can break existing deployments that mounted config at the old `/etc/collector/config.yaml` path.
> 
> **Overview**
> Aligns all production Docker images to use `/etc/radar/radar-collector.yml` instead of `/etc/collector/config.yaml` for the default config path (directory creation, `COPY`, `COLLECTOR_CONFIG`, `VOLUME`, and default `CMD`).
> 
> Updates the distroless image to create and mount `/etc/radar`, set `COLLECTOR_CONFIG`, and default to running `radar-collector --config /etc/radar/radar-collector.yml` instead of `--help`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07c0b7c3ad87cdebd316e2f49de41c52d2d64d4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->